### PR TITLE
imp(ci): use cache from actions/setup-node

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -19,11 +19,3 @@ runs:
 
         - run: echo "COMPOSER_CACHE_DIR=${{ steps.composer-cache.outputs.dir }}" >> $GITHUB_ENV
           shell: bash
-
-        # Yarn cache
-        - id: yarn-cache-dir
-          run: echo "::set-output name=dir::$(yarn cache dir)"
-          shell: bash
-
-        - run: echo "YARN_CACHE_DIR=${{ steps.yarn-cache-dir.outputs.dir }}" >> $GITHUB_ENV
-          shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,18 +35,13 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: ${{ env.NODE_VERSION }}
-
+                  cache: 'yarn'
+    
             - uses: actions/cache@v2
               with:
                   path: ${{ env.COMPOSER_CACHE_DIR }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
                   restore-keys: ${{ runner.os }}-composer-
-
-            - uses: actions/cache@v2
-              with:
-                  path: ${{ env.YARN_CACHE_DIR }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: ${{ runner.os }}-yarn-
 
             # Check dependencies
             - run: symfony composer validate
@@ -98,18 +93,13 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: ${{ env.NODE_VERSION }}
-
+                  cache: 'yarn'
+    
             - uses: actions/cache@v2
               with:
                   path: ${{ env.COMPOSER_CACHE_DIR }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
                   restore-keys: ${{ runner.os }}-composer-
-
-            - uses: actions/cache@v2
-              with:
-                  path: ${{ env.YARN_CACHE_DIR }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: ${{ runner.os }}-yarn-
 
             - run: make setup@integration
 
@@ -162,18 +152,13 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: ${{ env.NODE_VERSION }}
-
+                  cache: 'yarn'
+    
             - uses: actions/cache@v2
               with:
                   path: ${{ env.COMPOSER_CACHE_DIR }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
                   restore-keys: ${{ runner.os }}-composer-
-
-            - uses: actions/cache@v2
-              with:
-                  path: ${{ env.YARN_CACHE_DIR }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: ${{ runner.os }}-yarn-
 
             - run: make setup@integration
 


### PR DESCRIPTION
https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/